### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,4 +357,4 @@ If you find our work useful, please cite:
 ```
 
 If you like our project, please give us a star ⭐ on [GitHub](https://github.com/showlab/Code2Video) for the latest update!
-[![Star History Chart](https://api.star-history.com/svg?repos=showlab/Code2Video&type=Date)](https://star-history.com/#showlab/Code2Video&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=showlab/Code2Video&type=Date)](https://star-history.dera.page/#showlab/Code2Video&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,4 +211,4 @@ src/
 ```
 
 如果您喜欢我们的项目，欢迎在 GitHub 上给我们一个 Star ⭐ 以获取最新动态！
-[![Star History Chart](https://api.star-history.com/svg?repos=showlab/Code2Video&type=Date)](https://star-history.com/#showlab/Code2Video&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=showlab/Code2Video&type=Date)](https://star-history.dera.page/#showlab/Code2Video&Date)


### PR DESCRIPTION
The star history chart shown in the README is currently broken due to restrictions on the GitHub stargazer API. This change points the chart to a working replacement so the chart displays correctly again.